### PR TITLE
Added tests for component TextTag

### DIFF
--- a/src/Components/TextTag.test.js
+++ b/src/Components/TextTag.test.js
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import TextTag from './TextTag';
+
+describe('<TextTag text="foo" url="/offers" />', () => {
+  let component
+  beforeEach(() => {
+    component = render(
+      <BrowserRouter>
+        <TextTag text="foo" url="/offers" />
+      </BrowserRouter>
+    );
+  })
+
+  test('not render an paragraph tag', async () => {
+    const paragraphElement = component.container.querySelector(['p'])
+    expect(paragraphElement).toBeNull()
+  });
+
+  test('render an anchor passing it an url in his props', async () => {
+    const anchorElement = component.container.querySelector(['a'])
+    expect(anchorElement).toBeInTheDocument()
+  });
+
+  test('render an anchor with "href" attribute passing it an url in his props', async () => {
+    const anchorElement = component.container.querySelector(['a'])
+    expect(anchorElement).toHaveAttribute("href")
+  });
+
+  test('render an anchor with "href" attribute and value "/offers" using TexTag', async () => {
+    const attributeHrefValue = component.container.querySelector(['a']).attributes['href'].value
+    expect(attributeHrefValue).toBe("/offers")
+  });
+  
+  test('render a text ("foo") inside component TextTag', async () => {
+    const textInScreen = screen.getByText("foo")
+    expect(textInScreen).toBeInTheDocument()
+  });
+
+  test('render a text ("foo") between anchor tags', async () => {
+    const anchorElement = component.container.querySelector(['a'])
+    expect(anchorElement).toHaveTextContent("foo")
+  });
+})
+
+
+describe('<TextTag text="bar" url="" />', () => {
+  let component
+  beforeEach(() => {
+    component = render(
+      <BrowserRouter>
+        <TextTag text="bar" url="" />
+      </BrowserRouter>
+    );
+  })
+
+  test('not render an anchor tag', async () => {
+    const anchorElement = component.container.querySelector(['a'])
+    expect(anchorElement).toBeNull()
+  });
+
+  test('render a paragraph tag', async () => {
+    const paragraphElement = component.container.querySelector(['p'])
+    expect(paragraphElement).toBeInTheDocument()
+  });
+
+  test('render a text ("bar") inside component TextTag', async () => {
+    const textInScreen = screen.getByText("bar")
+    expect(textInScreen).toBeInTheDocument()
+  });
+
+  test('render a text ("bar") between paragraph tags', async () => {
+    const paragraphElement = component.container.querySelector(['p'])
+    expect(paragraphElement).toHaveTextContent("bar")
+  });
+})


### PR DESCRIPTION
# Creado los tests para el componente `TextTag`

## Issue: #32

## :memo: Resumen o Descripción:
- Añadido el archivo `TextTag.test.js` dentro de la carpeta `src/Components/`.
- Añadidos tests para comprobar que al pasar una url por `props` este renderiza una etiqueta `anchor`: `<a href=""></a>`.
- Añadidos tests para comprobar que al no pasar una url por `props` este renderiza una etiqueta `paragraph`: `<p></p>`.
- Añadidos tests para comprobar que el valor pasado por la `prop` `text` se renderice entre las etiquetas: `<a href=""></a>` o `<p></p>` según si se proporcionó al componente una url o no.

## :camera: Screenshots:
![Screenshot from 2021-11-17 17-58-15](https://user-images.githubusercontent.com/78811265/142283045-4b22ab33-650d-45d6-b66a-0ca808bb75cb.png)

