### PR TITLE
Feature 60 add trigger to navigation bar menu

### DIFF
--- a/src/Blocks/Navbar.js
+++ b/src/Blocks/Navbar.js
@@ -6,10 +6,10 @@ import MenuMobile from "./MenuMobile/MenuMobile";
 
 function Navbar() {
 
-  const [active,setActive] = useState(false)
+  const [activeMenu,setActiveMenu] = useState(false)
 
   const toggleMenu = () => {
-    setActive(!active)
+    setActiveMenu(!activeMenu)
   }
 
   return (
@@ -38,7 +38,7 @@ function Navbar() {
           </div>
         </div>
 
-        { active? <MenuMobile/> : ''}
+        { activeMenu? <MenuMobile/> : ''}
         
       </div>
   );

--- a/src/Blocks/Navbar.js
+++ b/src/Blocks/Navbar.js
@@ -1,10 +1,20 @@
+import { useState } from "react";
 import Icon from "../Components/Icon";
 import Logo from "../Components/Logo";
 import Input from "../Components/TextInput"
+import MenuMobile from "./MenuMobile/MenuMobile";
+
 function Navbar() {
+
+  const [active,setActive] = useState(false)
+
+  const toggleMenu = () => {
+    setActive(!active)
+  }
+
   return (
-      <div className="container bg-primary padding-none">
-        <div className="row navbar-p-base">
+      <div className="container  padding-none">
+        <div className="row bg-primary navbar-p-base">
             <div className="col padding-none navbar-width-logo">
                 <Logo imgAlt="Logo" imgSrc="https://http2.mlstatic.com/frontend-assets/ui-navigation/5.17.0/mercadolibre/logo__small@2x.png"/>
             </div>
@@ -12,7 +22,8 @@ function Navbar() {
                 <Input holderText="Estoy buscando..." className="input rounded shadow-sm navbar-p-input"/>
           </div>
           <div className="col padding-none">
-            <input
+            <input onClick={toggleMenu}
+              role="checkbox"
               type="checkbox"
               name="burger-btn-check"
               id="burger-btn-check"
@@ -26,6 +37,9 @@ function Navbar() {
           <Icon icon="cart"/>
           </div>
         </div>
+
+        { active? <MenuMobile/> : ''}
+        
       </div>
   );
 }

--- a/src/Blocks/Navbar.test.js
+++ b/src/Blocks/Navbar.test.js
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import Navbar from './Navbar'
 
@@ -38,6 +38,24 @@ describe("Navbar test", () => {
         it('should render two links to redirect', () => {
             const anchorsElement = screen.getAllByRole("link")
             expect(anchorsElement.length).toBe(2)
+        })
+    })
+
+    describe("Test for hamburger menu", () => {
+        beforeEach(() => {
+            render(<MockNavbar/>)
+        })
+
+        it("should render button hamburger menu", async () => {
+            const buttonElement = screen.getByRole("checkbox", {hidden: true})
+            expect(buttonElement).toBeInTheDocument()
+        })
+
+        it("should render menu mobile when clicked hamburger menu", async () => {
+            const buttonElement = screen.getByRole("checkbox", {hidden: true})
+            fireEvent.click(buttonElement)
+            const textElement = screen.getByText("Bienvenido/a")
+            expect(textElement).toBeInTheDocument()
         })
     })
 })


### PR DESCRIPTION
# Menú de navegación visible

## Issue: #60 

## :memo: Resumen o Descripción: 
Al hacer click en el menú hamburguesa se puede visualizar el menú de navegación y al volver a hacer click en el menú de hamburguesa se deja de visualizar

## :camera: Screenshots:
gift:
https://gyazo.com/245908f718917ce0aa602562ee707f04

![evidencia](https://user-images.githubusercontent.com/51139854/143625869-ec234d1e-5145-4796-bc0f-a7422cb0ed96.PNG)


