### PR TITLE
Fixed url static to dynamic

### DIFF
--- a/src/Pages/PublishingProcess/ChooseItemTitlePage/Components/RedirectBtn.js
+++ b/src/Pages/PublishingProcess/ChooseItemTitlePage/Components/RedirectBtn.js
@@ -24,7 +24,7 @@ export default function RedirectBtn({
   `)
 
   function handleclick() {
-    navigate('/')
+    navigate(url)
   }
 
   return (


### PR DESCRIPTION
# Arreglado la url estática a una dinámica usando `url`

## Issue: #89 

## :memo: Resumen o Descripción:
- Se cambió la url estática que tenía `redirectBtn` a una dinámica usando `url` que viene por propiedad del componente.

## :camera: Screenshots:
![Screenshot from 2021-11-29 15-15-00](https://user-images.githubusercontent.com/78811265/143921221-0cb7bf08-7aa0-442f-9181-ae4a4eb93da8.png)

