### PR TITLE
Fix 91 redirect to product detail

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/offers" element={<OffersPage />} />
-        <Route path="/product" element={<ProductPage />} />
+        <Route path="/product/:id" element={<ProductPage />} />
         <Route path="/ayuda/terminos-y-condiciones" element={<TermsAndConditionsPage />} />
         <Route path="/ayuda/defensa-del-consumidor" element={<DefensaConsumidorPage />} />
         <Route path="/sell/chooseCategory" element={<ChooseRootCategory />} />

--- a/src/Pages/HomePage/ProductItem.js
+++ b/src/Pages/HomePage/ProductItem.js
@@ -2,7 +2,7 @@ import TextLine from '../../Components/TextLine'
 import Icon from '../../Components/Icon'
 import { Link } from 'react-router-dom'
 
-function ProductItem({item, orientation = 'vertical'}) {
+function ProductItem({item, orientation = 'vertical', dataTestId = ''}) {
 
     const freeShippingText = 'Envío gratis'
     const badge = '$'
@@ -24,7 +24,7 @@ function ProductItem({item, orientation = 'vertical'}) {
     }
 
     return (
-        <Link className={'link br-btm'} to={"/login"}>
+        <Link data-testid={dataTestId} className={'link br-btm'} to={"/product/" + item.id}>
             <div className={`row p-0 ${classes.direction}`}>
                 <img className={`${classes.imageSize}`} src={item.image} alt={item.title}/>
 

--- a/src/Pages/HomePage/ProductItem.test.js
+++ b/src/Pages/HomePage/ProductItem.test.js
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import HomePage from '../Public/HomePage'
+
+const MockNavbar = () => {
+    return (
+        <BrowserRouter>
+            <HomePage/>
+        </BrowserRouter>
+    )
+}
+
+describe("ProductItem", () => {
+    it("should redirect to product detail when clicked a product", async () => {
+        render(<MockNavbar/>)
+        const divElement = screen.getByTestId("product-detail-1")
+        expect(divElement.getAttribute("href")).toBe("/product/1")
+    })
+})

--- a/src/Pages/Public/HomePage.js
+++ b/src/Pages/Public/HomePage.js
@@ -56,6 +56,7 @@ function HomePage() {
                                 key={product.id}
                                 orientation = "horizontal"
                                 item = {product}
+                                dataTestId={`product-detail-${product.id}`}
                             />
                         )
                     })}


### PR DESCRIPTION
# Arreglo de link a las tarjetas de los productos

## Issue: #91 

## :memo: Resumen o Descripción:
- Se agrego el parámetro dinámico en la ruta de `product/:id`
- Se cambio la url de redireccionamiento del componente `ProductItem` de `to={/login}` a `to={"/product/" + item.id}`

## :camera: Screenshots
![evidencia1](https://user-images.githubusercontent.com/51139854/143927503-5fce29c9-5108-400d-b5be-82cb3cc24af7.PNG)
:

https://gyazo.com/0a2604cf21798522fff638850c3857ef
