### PR TITLE
Fix 93 boton crear cuenta 

### DIFF
--- a/src/Pages/HomePage/CreateAccountCard.js
+++ b/src/Pages/HomePage/CreateAccountCard.js
@@ -14,7 +14,7 @@ export function CreateAccountCard() {
                 <p className="txt-bold m-bottom-0 HomePage-fs-18">{titleText}</p>
                 <Link to="/register">
                     <button type="button" className="rounded bg-blue HomePage-border-none txt-white p-0 m-bottom-0 HomePage-fs-16 MenuMobile-width-100" >{buttonText}</button>
-				</Link>
+                </Link>
                 <p className="txt-grey txt-center HomePage-fs-16">
                     {footerText}
                     <TextLink url={'/login'} className={'txt-blue'}>{linkText}</TextLink>

--- a/src/Pages/HomePage/CreateAccountCard.js
+++ b/src/Pages/HomePage/CreateAccountCard.js
@@ -1,4 +1,5 @@
 import TextLink from "../../Components/TextLink"
+import { Link } from "react-router-dom"
 
 export function CreateAccountCard() {
 
@@ -11,7 +12,9 @@ export function CreateAccountCard() {
         <div className="row">
             <div className="col HomePage-col-12 bg-white shadow-sm rounded p-0 HomePage-d-flex fd-col">
                 <p className="txt-bold m-bottom-0 HomePage-fs-18">{titleText}</p>
-                <button type="button" className="rounded bg-blue HomePage-border-none txt-white p-0 m-bottom-0 HomePage-fs-16" >{buttonText}</button>
+                <Link to="/register">
+                    <button type="button" className="rounded bg-blue HomePage-border-none txt-white p-0 m-bottom-0 HomePage-fs-16 MenuMobile-width-100" >{buttonText}</button>
+				</Link>
                 <p className="txt-grey txt-center HomePage-fs-16">
                     {footerText}
                     <TextLink url={'/login'} className={'txt-blue'}>{linkText}</TextLink>

--- a/src/Pages/HomePage/CreateAccountCard.test.js
+++ b/src/Pages/HomePage/CreateAccountCard.test.js
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import CreateAccountCard from "./CreateAccountCard";
+describe("MenuMobile", () => {
+	let component;
+
+	beforeEach(() => {
+		component = render(
+			<BrowserRouter>
+				<CreateAccountCard />
+			</BrowserRouter>
+		);
+	});
+
+	it("should include '/register' as href", () => {
+		expect(
+			component.getByText("Crear cuenta").closest("a")
+		).toHaveAttribute("href", "/register");
+	});
+
+});


### PR DESCRIPTION
# Title: Fix: boton "Crear cuenta" no redirige a register

## Issue: #93

## :memo: Resumen o Descripción:  
* Se añadió una ruta al boton del componente `CreateAccountCard` para que redirija a la pagina  `/register`
* Se testeó que el boton `Crear cuenta` redirija a la ruta solicitada

## :camera: Screenshots
![record_211129_172150](https://user-images.githubusercontent.com/69168381/143938366-80518e32-d23c-48b4-aff3-d0e7a32803f2.gif)
![Captura](https://user-images.githubusercontent.com/69168381/143942787-b7b0ad84-faaf-4a0b-80be-52887d74bcc5.PNG)
:
