### PR TITLE
Fix 95 advertisement card

### DIFF
--- a/src/Pages/HomePage/Advertisement.js
+++ b/src/Pages/HomePage/Advertisement.js
@@ -5,7 +5,7 @@ function Advertisement({item, textLink}) {
     return (
         <div className="row">
             <div className="col bg-white rounded shadow-sm padding-none HomePage-col-12">
-                <Link className={"link"} to={"/login"}>
+                <Link className={"link"} to={item.redirect}>
                     <div className="HomePage-d-flex padding-none">
                         <div className="p-0 HomePage-d-flex fd-col HomePage-flex-grow-1">
                             <TextLine className={"txt-black txt-bold HomePage-txt-start HomePage-fs-12"} text={item.title}/>

--- a/src/Pages/HomePage/Advertisement.test.js
+++ b/src/Pages/HomePage/Advertisement.test.js
@@ -1,0 +1,28 @@
+import { render, screen} from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import Advertisement from './Advertisement'
+
+describe('Advertisement component test', () => {
+
+    it('should render the component <Advertisement /> with a link passed by prop on an object data', () => {
+
+        const advertisement =  {
+            'title': "PEQUEÑOS ELECTRO",
+            'body1': "EQUIPÁ TU HOGAR",
+            'body2': "EN 6X SIN INTERÉS",
+            'image': "https://http2.mlstatic.com/D_NQ_684569-MLA48136225881_112021-C.webp",
+            'redirect': "/offers"
+        }
+
+        render(
+            <BrowserRouter>
+                <Advertisement item={advertisement} textLink="Ver más"/>
+            </BrowserRouter>
+        )
+        
+        const anchorElement = screen.getByRole('link')
+        const redirect = anchorElement.attributes["href"].value
+        expect(redirect).toBe('/offers')
+    })
+    
+})

--- a/src/Pages/HomePage/Data/advertisementsData.js
+++ b/src/Pages/HomePage/Data/advertisementsData.js
@@ -4,25 +4,29 @@ const advertisementList = [
         'title': "PEQUEÑOS ELECTRO",
         'body1': "EQUIPÁ TU HOGAR",
         'body2': "EN 6X SIN INTERÉS",
-        'image': "https://http2.mlstatic.com/D_NQ_684569-MLA48136225881_112021-C.webp"
+        'image': "https://http2.mlstatic.com/D_NQ_684569-MLA48136225881_112021-C.webp",
+        'redirect': "/offers"
     },
     {
         'title': "PRODUCTOS PYMES",
         'body1': "OFERTAS HASTA",
         'body2': "12X SIN INTERÉS",
-        'image': "https://http2.mlstatic.com/D_NQ_757350-MLA48136577557_112021-C.webp"
+        'image': "https://http2.mlstatic.com/D_NQ_757350-MLA48136577557_112021-C.webp",
+        'redirect': "/offers"
     },
     {
         'title': "HERRAMIENTAS",
         'body1': "HASTA 40% OFF",
         'body2': "Y 6X SIN INTERÉS",
-        'image': "https://http2.mlstatic.com/D_NQ_971474-MLA48135672229_112021-C.webp"
+        'image': "https://http2.mlstatic.com/D_NQ_971474-MLA48135672229_112021-C.webp",
+        'redirect': "/offers"
     },
     {
         'title': "POINT MINI",
         'body1': "NUEVO POINT MINI",
         'body2': "¡COMPRALO AHORA!",
-        'image': "https://http2.mlstatic.com/D_NQ_902536-MLA47888168890_102021-C.webp"
+        'image': "https://http2.mlstatic.com/D_NQ_902536-MLA47888168890_102021-C.webp",
+        'redirect': "/login"
     }
 ]
 


### PR DESCRIPTION
# Modificado el link para redireccionar dinámicamente en tarjeta de anuncio

## Issue: #95

## :memo: Resumen o Descripción:
Se agregó la propiedad `redirect` en el archivo `advertisementData.js` para simular un link dinámico traído desde una llamada a la API.
Se modificó el link para redireccionar en el componente `Advertisement`.
Se creó un test para verificar que el link renderizado es el link pasado por parámetro en un objeto a través de las props del componente.

## :camera: Screenshots:

![record_211130_215726](https://user-images.githubusercontent.com/66789019/144153107-6110f6f8-178e-4a5e-9348-a1d5bfa6523b.gif)


![Captura de pantalla 2021-11-30 213844](https://user-images.githubusercontent.com/66789019/144153121-13bcfbc1-f53e-4e69-9a4a-06c1e83323fd.png)


