### PR TITLE
Fix 120 remove universal selector

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,10 +5,6 @@
 	--margin-base: 6px;
 }
 
-* {
-	color: var(--black);
-}
-
 .texttag-container {
 	display: inline-flex;
 	padding: 3px 4px;


### PR DESCRIPTION
# Fix: quitar color negro aplicado a todos los componentes

## Issue: #120 

## :memo: Resumen o Descripción:
Se eliminó el selector universal que aplicaba la propiedad `color` a todos los elementos en `App.css`.

## :camera: Screenshots:
**Antes:**
![Captura de pantalla 2021-12-09 160244](https://user-images.githubusercontent.com/66789019/145462170-59889546-011d-4c1b-98dc-f8da05983728.png)

**Después:**
![Captura de pantalla 2021-12-09 160600](https://user-images.githubusercontent.com/66789019/145462205-e6ba6a73-ddaa-4055-9834-7a0aa52256e2.png)

