### PR TITLE
Fix 109 110 alineacion titulo iconos categories page

### DIFF
--- a/src/Pages/CategoriesPage/CategoriesPage.js
+++ b/src/Pages/CategoriesPage/CategoriesPage.js
@@ -10,7 +10,7 @@ function CategoriesPage () {
     <WebsiteLayout>
       <div className="row bg-main">
         <div className="col w-100">
-          <h3>Categorías</h3>
+          <h3 className='m-left-4'>Categorías</h3>
           <div className="row w-100">
             <div className="col bg-white rounded shadow-sm padding-none d-flex w-100 fd-col">
               {services.map((service) => {

--- a/src/Pages/CategoriesPage/CategoriesPageItem.js
+++ b/src/Pages/CategoriesPage/CategoriesPageItem.js
@@ -3,7 +3,7 @@ import TextLink from '../../Components/TextLink'
 
 function CategoriesPageItem ({categoryData}) {
   return(
-      <TextLink className="d-flex w-100 p-0 br-btm justify-content-sb" url="/">
+      <TextLink className="d-flex w-100 p-0 br-btm justify-content-sb ai-center" url="/">
         {categoryData.category}
         <Icon icon="arrow-right"/>
     </TextLink>


### PR DESCRIPTION
# Alineación título iconos Categories page

## Issue: #109 #110 

## :memo: Resumen o Descripción:

- [x] Alinear el título de la página de categorías con las cards, se agregó la clase `m-left-4`.
- [x] Alinear los íconos en el centro del div, se agregó la clase `ai-center` al componente categoriesPageItem donde se utiliza el icono de la flecha.

## :camera: Screenshots:
Antes
![image](https://user-images.githubusercontent.com/69699380/145467600-c3f3bd8c-9c47-4e91-928f-3dad5567e095.png)

Después
![image](https://user-images.githubusercontent.com/69699380/145467676-ee255ccc-0f49-4cb2-a60f-b3536de29724.png)
