### PR TITLE
Fix 124 border radius text

### DIFF
--- a/public/rooftstrap.css
+++ b/public/rooftstrap.css
@@ -398,7 +398,3 @@ p::after {
 .bg-black-transparent {
     background-color: rgba(0,0,0,.3);
 }
-.comment-box{
-  resize: none;
-  border-radius: 8px;
-}

--- a/public/rooftstrap.css
+++ b/public/rooftstrap.css
@@ -398,3 +398,7 @@ p::after {
 .bg-black-transparent {
     background-color: rgba(0,0,0,.3);
 }
+.comment-box{
+  resize: none;
+  border-radius: 8px;
+}

--- a/src/Pages/Public/ProductPage/Component/AutoGrowTextAreaComponent.js
+++ b/src/Pages/Public/ProductPage/Component/AutoGrowTextAreaComponent.js
@@ -4,7 +4,7 @@
 function AutoGrowTextAreaComponent() {
   return (
     <textarea
-      className="input p-0"
+      className="input p-0 comment-box"
       placeholder="Escribí tu pregunta..."
       defaultValue={""}
     />

--- a/src/Pages/Public/ProductPage/Component/AutoGrowTextAreaComponent.js
+++ b/src/Pages/Public/ProductPage/Component/AutoGrowTextAreaComponent.js
@@ -4,7 +4,7 @@
 function AutoGrowTextAreaComponent() {
   return (
     <textarea
-      className="input p-0 comment-box"
+      className="input p-0 rounded ChooseItemTitle-resize-none"
       placeholder="Escribí tu pregunta..."
       defaultValue={""}
     />


### PR DESCRIPTION
# Se agregó propiedades para el textarea

## Issue: #124 

## :memo: Resumen o Descripción: Se agregan propiedades mediante la clase `.comment-box` para ser aplicadas en el textarea. 

Las propiedades utilizadas fueron `resize: none` y `border-radius: 8px`

## :camera: Screenshots:
![image](https://user-images.githubusercontent.com/84633047/145471281-a1c146b4-7d31-4176-8bbc-4866e789a324.png)
