### PR TITLE
Fix 128 multiple purchases shopping page

### DIFF
--- a/src/Pages/ShoppingHistoryPage/ShoppingHistoryData.js
+++ b/src/Pages/ShoppingHistoryPage/ShoppingHistoryData.js
@@ -2,34 +2,48 @@ const ShoppingHistoryData = [
   {
     id: 1,
     shoppingDate: '14 de Octubre',
-    productName: 'Pellet Sanitario Vegetal Poopy Pets 25 Kg',
-    img: 'https://http2.mlstatic.com/D_776646-MLA47291405232_082021-I.jpg',
-    shippingStatus: 'En camino',
-    deliveryDate: 'Tu compra llega el 16 de Octubre'
+    products: [
+      {
+        productId: 1,
+        productName: 'Pellet Sanitario Vegetal Poopy Pets 25 Kg',
+        img: 'https://http2.mlstatic.com/D_776646-MLA47291405232_082021-I.jpg',
+        shippingStatus: 'En camino',
+        deliveryDate: 'Tu compra llega el 16 de Octubre'
+      }
+    ]
   },
   {
     id: 2,
     shoppingDate: '21 de Septiembre',
-    productName: 'Ruedas Para Silla Giratoria De Oficina Reforzadas Pack X 5',
-    img: 'https://http2.mlstatic.com/D_624116-MLA44023587000_112020-I.jpg',
-    shippingStatus: 'Entregado',
-    deliveryDate: 'Llegó el 22 de Septiembre'
+    products: [
+      {
+        productId: 2,
+        productName: 'Ruedas Para Silla Giratoria De Oficina Reforzadas Pack X 5',
+        img: 'https://http2.mlstatic.com/D_624116-MLA44023587000_112020-I.jpg',
+        shippingStatus: 'Entregado',
+        deliveryDate: 'Llegó el 22 de Septiembre'
+      }
+    ]
   },
   {
     id: 3,
     shoppingDate: '19 de Septiembre',
-    productName: 'Cable Usb Tipo C 2 Metros Carga Rapida',
-    img: 'https://http2.mlstatic.com/D_621066-MLA48187015333_112021-I.jpg',
-    shippingStatus: 'Entregado',
-    deliveryDate: 'Llegó el 20 de Septiembre'
-  },
-  {
-    id: 4,
-    shoppingDate: '14 de Octubre',
-    productName: 'Cable Hdmi 1,2m Macho Macho Full Hd 1080p - Polotecno',
-    img: 'https://http2.mlstatic.com/D_915319-MLA31114614647_062019-I.jpg',
-    shippingStatus: 'Entregado',
-    deliveryDate: 'Llegó el 20 de Septiembre'
+    products: [
+      {
+        productId: 3,
+        productName: 'Cable Usb Tipo C 2 Metros Carga Rapida',
+        img: 'https://http2.mlstatic.com/D_621066-MLA48187015333_112021-I.jpg',
+        shippingStatus: 'Entregado',
+        deliveryDate: 'Llegó el 20 de Septiembre'
+      },
+      {
+        productId: 4,
+        productName: 'Cable Hdmi 1,2m Macho Macho Full Hd 1080p - Polotecno',
+        img: 'https://http2.mlstatic.com/D_915319-MLA31114614647_062019-I.jpg',
+        shippingStatus: 'Entregado',
+        deliveryDate: 'Llegó el 20 de Septiembre'
+      }
+    ]
   },
 ]
 

--- a/src/Pages/ShoppingHistoryPage/ShoppingHistoryItem.js
+++ b/src/Pages/ShoppingHistoryPage/ShoppingHistoryItem.js
@@ -10,7 +10,7 @@ function ShoppingHistoryItem({shoppingData}) {
           </p>
           {
             data.products.map((item) => {
-              return <ShoppingHistoryProduct productData = {item} />
+              return <ShoppingHistoryProduct productData = {item} key={item.productId} />
             })
           }
         </div>

--- a/src/Pages/ShoppingHistoryPage/ShoppingHistoryItem.js
+++ b/src/Pages/ShoppingHistoryPage/ShoppingHistoryItem.js
@@ -1,3 +1,5 @@
+import ShoppingHistoryProduct from './ShoppingHistoryProduct'
+
 function ShoppingHistoryItem({shoppingData}) {
   const data = shoppingData
   return (
@@ -6,17 +8,11 @@ function ShoppingHistoryItem({shoppingData}) {
           <p className="txt-black txt-bold br-btm p-0">
             {data.shoppingDate}
           </p>
-          <div className="p-2 d-flex">
-            <img src={data.img} alt={data.productName} className="grey-border horizontal-product-img" />
-            <div className="m-left-1 d-flex fd-col">
-              <p className="txt-green txt-bold">
-                {data.shippingStatus}
-              </p>
-              <p>
-                {data.deliveryDate}
-              </p>
-            </div>
-          </div>
+          {
+            data.products.map((item) => {
+              return <ShoppingHistoryProduct productData = {item} />
+            })
+          }
         </div>
       </div>
   )

--- a/src/Pages/ShoppingHistoryPage/ShoppingHistoryProduct.js
+++ b/src/Pages/ShoppingHistoryPage/ShoppingHistoryProduct.js
@@ -1,0 +1,19 @@
+function ShoppingHistoryProduct({ productData }) {
+  const product = productData
+
+  return (
+    <div className="p-2 d-flex br-btm">
+      <img src={product.img} alt={product.productName} className="grey-border horizontal-product-img" />
+      <div className="m-left-1 d-flex fd-col">
+        <p className="txt-green txt-bold">
+          {product.shippingStatus}
+        </p>
+        <p>
+          {product.deliveryDate}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default ShoppingHistoryProduct


### PR DESCRIPTION
# Agregar un ejemplo de múltiples compras en la misma fecha

## Issue: #128 

## :memo: Resumen o Descripción:
Se agregó un componente `ShoppingHistoryProduct` para poder mostrar varios productos comprados en la misma fecha.

Se cambió la estructura del json agregando un listado de productos por fecha

## :camera: Screenshots:
Antes:
![image](https://user-images.githubusercontent.com/69699380/145472735-77d02e37-7763-47ea-a4dd-0a12afe70199.png)

Después:
![image](https://user-images.githubusercontent.com/69699380/145472769-3e6213cc-793f-4362-9ce2-0fe1f92601a4.png)
