### PR TITLE
Se eliminan los rows innecesarios en ProductPage

### DIFF
--- a/src/Pages/Public/ProductPage/Block/QuestionAndAnswerBlock.js
+++ b/src/Pages/Public/ProductPage/Block/QuestionAndAnswerBlock.js
@@ -8,7 +8,7 @@ function QuestionAndAnswerBlock() {
   return (
     <section className="shadow-sm">
       <div className="row">
-        <div className="col ProductPage-w-100">
+        <div className="col ProductPage-w-100 padding-none">
           <h3 className="m-top-2 m-bottom-4">
             Preguntas y respuestas
           </h3>

--- a/src/Pages/Public/ProductPage/Block/QuestionAndAnswerBlock.js
+++ b/src/Pages/Public/ProductPage/Block/QuestionAndAnswerBlock.js
@@ -12,21 +12,19 @@ function QuestionAndAnswerBlock() {
           <h3 className="m-top-2 m-bottom-4">
             Preguntas y respuestas
           </h3>
-          <p className="txt-bold">¿Qué querés saber?</p>
-          <div className="row">
-            <div className="ProductPage-flex-container">
-              {mock_keywordInformation.map((keyword) => (
-                <KeywordInformationButtonComponent key={keyword}>
-                  {keyword}
-                </KeywordInformationButtonComponent>
-              ))}
-            </div>
+          <p className="txt-bold OffersPage-m-bottom">¿Qué querés saber?</p>
+          <div className="ProductPage-flex-container">
+            {mock_keywordInformation.map((keyword) => (
+              <KeywordInformationButtonComponent key={keyword}>
+                {keyword}
+              </KeywordInformationButtonComponent>
+            ))}
           </div>
 
-          <p className="txt-bold">Preguntale al vendedor</p>
-          <div className="row">
-            <AutoGrowTextAreaComponent />
-          </div>
+          <p className="txt-bold SearchHelp-m-3-top OffersPage-m-bottom">
+            Preguntale al vendedor
+          </p>
+          <AutoGrowTextAreaComponent />
           <button className="rounded txt-white p-0 bg-blue ProductPage-w-100 input">
             Preguntar
           </button>


### PR DESCRIPTION
# Se eliminaron los rows que causaban padding indeseado en la sección de Preguntas y respuestas en ProductPage

## Issue: #123 

## Antes
![image](https://user-images.githubusercontent.com/39138605/145501484-d472b3d0-471f-4f62-a0a0-6710f7365865.png)

## Despues
![image](https://user-images.githubusercontent.com/39138605/145503966-1211c59d-f937-4140-8b6f-f325d0bad6d1.png)
