### PR TITLE
Fix 129 links footer

### DIFF
--- a/src/Blocks/Footer/FooterHeader.js
+++ b/src/Blocks/Footer/FooterHeader.js
@@ -5,7 +5,7 @@ function FooterHeader() {
     return (
         <div className='row bg-primary'>
             <div className='col'>
-                <Link className={'link'} to={'/login'}>
+                <Link className={'link'} to={'/'}>
                     <div className='row padding-none'>
                         <div className='col shadow-sm rounded Footer-w-50px'>
                             <img className="Footer-img" src="https://http2.mlstatic.com/frontend-assets/ui-navigation/5.17.0/mercadolibre/logo__small@2x.png" alt="Logo" />

--- a/src/Blocks/Footer/FooterHeader.test.js
+++ b/src/Blocks/Footer/FooterHeader.test.js
@@ -19,11 +19,11 @@ describe( "Header", () => {
 
     })
 
-    it("should render the component <FooterHeader/> with the link '/home'", () => {
+    it("should render the component <FooterHeader/> with the link '/'", () => {
         render(<MockFooterHeader />);
         const htmlValue = screen.getByRole("link")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/home");
+        expect(variable).toBe("/");
         
     })
 

--- a/src/Blocks/Footer/FooterInfo.js
+++ b/src/Blocks/Footer/FooterInfo.js
@@ -6,7 +6,7 @@ function FooterInfo() {
         <div className='row'>
             <div className='col'>
                 <TextLink url={'/ayuda/terminos-y-condiciones'} className={'txt-black m-right-0'}>Términos y condiciones</TextLink>
-                <TextLink url={'/privacidad'} className={'txt-black m-right-0'}>Cómo cuidamos tu privacidad</TextLink>
+                <TextLink url={'/privacy'} className={'txt-black m-right-0'}>Cómo cuidamos tu privacidad</TextLink>
                 <TextLink url={'/ayuda/defensa-del-consumidor'} className={'txt-black m-right-0'}>Defensa del Consumidor</TextLink>
                 <TextLink url={'/financial-user-info'} className={'txt-black m-right-0'}>Información al usuario financiero</TextLink>
                 <TextLine className={'txt-light-grey m-top-0 Footer-txt-start'} text={'© 1999-2021 MercadoLibre S.R.L.'}/>

--- a/src/Blocks/Footer/FooterInfo.js
+++ b/src/Blocks/Footer/FooterInfo.js
@@ -6,7 +6,7 @@ function FooterInfo() {
         <div className='row'>
             <div className='col'>
                 <TextLink url={'/ayuda/terminos-y-condiciones'} className={'txt-black m-right-0'}>Términos y condiciones</TextLink>
-                <TextLink url={'/login'} className={'txt-black m-right-0'}>Cómo cuidamos tu privacidad</TextLink>
+                <TextLink url={'/privacidad'} className={'txt-black m-right-0'}>Cómo cuidamos tu privacidad</TextLink>
                 <TextLink url={'/ayuda/defensa-del-consumidor'} className={'txt-black m-right-0'}>Defensa del Consumidor</TextLink>
                 <TextLink url={'/financial-user-info'} className={'txt-black m-right-0'}>Información al usuario financiero</TextLink>
                 <TextLine className={'txt-light-grey m-top-0 Footer-txt-start'} text={'© 1999-2021 MercadoLibre S.R.L.'}/>

--- a/src/Blocks/Footer/FooterInfo.test.js
+++ b/src/Blocks/Footer/FooterInfo.test.js
@@ -32,10 +32,10 @@ describe( "Info", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterInfo/> with the link '/privacidad'", () => {
+    it("should render the component <FooterInfo/> with the link '/privacy'", () => {
         const htmlValue = screen.getByText("Cómo cuidamos tu privacidad")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/privacidad");
+        expect(variable).toBe("/privacy");
     })
 
     it("should render the component <FooterInfo/> with the text 'Información al usuario financiero'", async () => {

--- a/src/Blocks/Footer/FooterInfo.test.js
+++ b/src/Blocks/Footer/FooterInfo.test.js
@@ -43,20 +43,20 @@ describe( "Info", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterInfo/> with the link '/informacion-usuario'", () => {
+    it("should render the component <FooterInfo/> with the link '/financial-user-info'", () => {
         const htmlValue = screen.getByText("Información al usuario financiero")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/informacion-usuario");
+        expect(variable).toBe("/financial-user-info");
     })
     it("should render the component <FooterInfo/> with the text 'Defensa del Consumidor'", async () => {
         const footerInfo = screen.getByText("Defensa del Consumidor");
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterInfo/> with the link '/defensa-del-consumidor'", () => {
+    it("should render the component <FooterInfo/> with the link '/ayuda/defensa-del-consumidor'", () => {
         const htmlValue = screen.getByText("Defensa del Consumidor")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/defensa-del-consumidor");
+        expect(variable).toBe("/ayuda/defensa-del-consumidor");
     })
 
 })    

--- a/src/Blocks/Footer/FooterLogin.js
+++ b/src/Blocks/Footer/FooterLogin.js
@@ -6,7 +6,7 @@ function FooterLogin() {
             <div className='col'>
                 <TextLink url={'/login'} className={'txt-blue m-right-0'}>Ingresá</TextLink>
                 <span className='br-right'/>
-                <TextLink url={'/login'} className={'txt-blue m-left-0'}>Creá tu cuenta</TextLink>
+                <TextLink url={'/register'} className={'txt-blue m-left-0'}>Creá tu cuenta</TextLink>
             </div>
         </div>
     )

--- a/src/Blocks/Footer/FooterLogin.test.js
+++ b/src/Blocks/Footer/FooterLogin.test.js
@@ -33,7 +33,7 @@ describe( "Login", () => {
 
     it("should render the component <FooterLogin/> with the link /register", () => {
         render(<MockFooterLogin />);
-        const htmlValue = screen.getByText("Ingresá")
+        const htmlValue = screen.getByText("Creá tu cuenta")
         const variable = htmlValue.attributes["href"].value
         expect(variable).toBe("/register");
     })

--- a/src/Blocks/Footer/FooterMenu.js
+++ b/src/Blocks/Footer/FooterMenu.js
@@ -4,18 +4,18 @@ function FooterMenu() {
     return (
         <div className='row'>
             <div className='col Footer-col-6 Footer-d-flex fd-col'>
-                <TextLink url={'/login'} className={'txt-black m-bottom-0'}>Mi cuenta</TextLink>
-                <TextLink url={'/login'} className={'txt-black m-bottom-0'}>Historial</TextLink>
-                <TextLink url={'/login'} className={'txt-black m-bottom-0'}>Favoritos</TextLink>
+                <TextLink url={'/my-acount'} className={'txt-black m-bottom-0'}>Mi cuenta</TextLink>
+                <TextLink url={'/navigation'} className={'txt-black m-bottom-0'}>Historial</TextLink>
+                <TextLink url={'/favourite'} className={'txt-black m-bottom-0'}>Favoritos</TextLink>
                 <TextLink url={'/categories'} className={'txt-black m-bottom-0'}>Categorias</TextLink>
-                <TextLink url={'/login'} className={'txt-black'}>Ayuda</TextLink>
+                <TextLink url={'/help'} className={'txt-black'}>Ayuda</TextLink>
             </div>
             <div className='col Footer-col-6 Footer-d-flex fd-col'>
                 <TextLink url={'/shopping-history'} className={'txt-black m-bottom-0'}>Mis Compras</TextLink>
-                <TextLink url={'/login'} className={'txt-black m-bottom-0'}>Ofertas</TextLink>
-                <TextLink url={'/login'} className={'txt-black m-bottom-0'}>Tiendas Oficiales</TextLink>
-                <TextLink url={'/login'} className={'txt-black m-bottom-0'}>Mercado Puntos</TextLink>
-                <TextLink url={'/login'} className={'txt-black'}>Vender</TextLink>
+                <TextLink url={'/offers'} className={'txt-black m-bottom-0'}>Ofertas</TextLink>
+                <TextLink url={'/officialStores'} className={'txt-black m-bottom-0'}>Tiendas Oficiales</TextLink>
+                <TextLink url={'/mercado-puntos'} className={'txt-black m-bottom-0'}>Mercado Puntos</TextLink>
+                <TextLink url={'/sell/chooseCategory'} className={'txt-black'}>Vender</TextLink>
             </div>
         </div>
     )

--- a/src/Blocks/Footer/FooterMenu.js
+++ b/src/Blocks/Footer/FooterMenu.js
@@ -6,7 +6,7 @@ function FooterMenu() {
             <div className='col Footer-col-6 Footer-d-flex fd-col'>
                 <TextLink url={'/my-acount'} className={'txt-black m-bottom-0'}>Mi cuenta</TextLink>
                 <TextLink url={'/navigation'} className={'txt-black m-bottom-0'}>Historial</TextLink>
-                <TextLink url={'/favourite'} className={'txt-black m-bottom-0'}>Favoritos</TextLink>
+                <TextLink url={'/favourites'} className={'txt-black m-bottom-0'}>Favoritos</TextLink>
                 <TextLink url={'/categories'} className={'txt-black m-bottom-0'}>Categorias</TextLink>
                 <TextLink url={'/help'} className={'txt-black'}>Ayuda</TextLink>
             </div>

--- a/src/Blocks/Footer/FooterMenu.test.js
+++ b/src/Blocks/Footer/FooterMenu.test.js
@@ -32,10 +32,10 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '/search'", () => {
+    it("should render the component <FooterMenu/> with the link '/navigation'", () => {
         const htmlValue = screen.getByText("Historial")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/search");
+        expect(variable).toBe("/navigation");
     })
 
     it("should render the component <FooterMenu/> with the text 'Favoritos'", async () => {
@@ -75,10 +75,10 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '/my-purchases'", () => {
+    it("should render the component <FooterMenu/> with the link '//shopping-history'", () => {
         const htmlValue = screen.getByText("Mis Compras")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/my-purchases");
+        expect(variable).toBe("/shopping-history");
     })
 
     it("should render the component <FooterMenu/> with the text 'Ofertas'", async () => {
@@ -89,7 +89,7 @@ describe( "Menu", () => {
     it("should render the component <FooterMenu/> with the link '/off'", () => {
         const htmlValue = screen.getByText("Ofertas")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/off");
+        expect(variable).toBe("/offers");
     })
 
     it("should render the component <FooterMenu/> with the text 'Tienda Oficiales'", async () => {
@@ -100,7 +100,7 @@ describe( "Menu", () => {
     it("should render the component <FooterMenu/> with the link '/tiendas-oficiales'", () => {
         const htmlValue = screen.getByText("Tiendas Oficiales")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/tiendas-oficiales");
+        expect(variable).toBe("/officialStores");
     })
 
     it("should render the component <FooterMenu/> with the text 'Mercado Puntos'", async () => {
@@ -122,7 +122,7 @@ describe( "Menu", () => {
     it("should render the component <FooterMenu/> with the link '/sell'", () => {
         const htmlValue = screen.getByText("Vender")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/sell");
+        expect(variable).toBe("/sell/chooseCategory");
     })
 
 })

--- a/src/Blocks/Footer/FooterMenu.test.js
+++ b/src/Blocks/Footer/FooterMenu.test.js
@@ -43,10 +43,10 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '/favourite'", () => {
+    it("should render the component <FooterMenu/> with the link '/favourites'", () => {
         const htmlValue = screen.getByText("Favoritos")
         const variable = htmlValue.attributes["href"].value
-        expect(variable).toBe("/favourite");
+        expect(variable).toBe("/favourites");
     })
 
     it("should render the component <FooterMenu/> with the text 'Categorias'", async () => {
@@ -75,7 +75,7 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '//shopping-history'", () => {
+    it("should render the component <FooterMenu/> with the link '/shopping-history'", () => {
         const htmlValue = screen.getByText("Mis Compras")
         const variable = htmlValue.attributes["href"].value
         expect(variable).toBe("/shopping-history");
@@ -86,7 +86,7 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '/off'", () => {
+    it("should render the component <FooterMenu/> with the link '/offers'", () => {
         const htmlValue = screen.getByText("Ofertas")
         const variable = htmlValue.attributes["href"].value
         expect(variable).toBe("/offers");
@@ -97,7 +97,7 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '/tiendas-oficiales'", () => {
+    it("should render the component <FooterMenu/> with the link '/officialStores", () => {
         const htmlValue = screen.getByText("Tiendas Oficiales")
         const variable = htmlValue.attributes["href"].value
         expect(variable).toBe("/officialStores");
@@ -119,7 +119,7 @@ describe( "Menu", () => {
         expect(footerInfo).toBeInTheDocument();
     })
 
-    it("should render the component <FooterMenu/> with the link '/sell'", () => {
+    it("should render the component <FooterMenu/> with the link '/sell/chooseCategory'", () => {
         const htmlValue = screen.getByText("Vender")
         const variable = htmlValue.attributes["href"].value
         expect(variable).toBe("/sell/chooseCategory");


### PR DESCRIPTION
# Title fix: links del footer no redirigen correctamente

## Issue: #129

## :memo: Resumen o Descripción: Se corrigió la navegación del footer para que redirija a sus paginas correspondientes
* Se corrigieron los link de los siguientes componentes:
`FooterHeader` 
`FooterMenu`
`FooterLogin`
`FooterInfo`
* Se actualizaron los siguientes test:
`FooterHeader.test` 
`FooterMenu.test`
`FooterLogin.test`
`FooterInfo.test`
## :camera: Screenshots:
![test](https://user-images.githubusercontent.com/69168381/145504582-7af59ee2-54dc-4490-9954-7f15afe820df.PNG)
![record_211209_230726](https://user-images.githubusercontent.com/69168381/145505423-7c840b94-9529-447f-989c-b054804b5e16.gif)

