### PR TITLE
fix: remove domain for icon paths in ChooseRootCategory.js

### DIFF
--- a/src/Pages/PublishingProcess/ChooseRootCategory.js
+++ b/src/Pages/PublishingProcess/ChooseRootCategory.js
@@ -5,10 +5,10 @@ import TextLink from "../../Components/TextLink";
 import ChooseCategoryItem from "./ChooseCategoryItem";
 
 const DataCategories = [
-    {name: 'Productos', icon: 'http://localhost:3000/productos.svg', url: '/'},
-    {name: 'Vehículos', icon: 'http://localhost:3000/vehiculos.svg', url: '/'},
-    {name: 'Inmuebles', icon: 'http://localhost:3000/inmuebles.svg', url: '/'},
-    {name: 'Servicios', icon: 'http://localhost:3000/servicios.svg', url: '/'},
+    {name: 'Productos', icon: '/productos.svg', url: '/'},
+    {name: 'Vehículos', icon: '/vehiculos.svg', url: '/'},
+    {name: 'Inmuebles', icon: '/inmuebles.svg', url: '/'},
+    {name: 'Servicios', icon: '/servicios.svg', url: '/'},
 ]
 
 function ChooseRootCategory () {


### PR DESCRIPTION
# Fix: las imágenes de las categorías no se renderizan

## Issue: #133 

## :memo: Resumen o Descripción:
* Se quitó el dominio `http://localhost:3000` de la ruta de los íconos en `ChooseRootCategory.js`

## :camera: Screenshots:
![Captura de pantalla 2021-12-09 231349](https://user-images.githubusercontent.com/66789019/145506130-3c453f2e-8805-46f2-bea2-10fba03a528f.png)

