### PR TITLE
Agregar clase txt-black a links

### DIFF
--- a/src/Components/SearchHelp/Components/SuggestedResultItem.js
+++ b/src/Components/SearchHelp/Components/SuggestedResultItem.js
@@ -8,7 +8,7 @@ function SuggestedResultsItem({ data: { suggested, redirect } }) {
   }
   return (
     <div className="row justify-content-sb padding-none SearchHelp-m-3-top">
-      <Link to={redirect} className="col link padding-none OffersPage-ai-center">
+      <Link to={redirect} className="txt-black col link padding-none OffersPage-ai-center">
         { forgetNormalIcon }
         <p className="txt-bold OffersPage-p-0-left">{ suggested }</p>
       </Link>

--- a/src/Pages/CategoriesPage/CategoriesPageItem.js
+++ b/src/Pages/CategoriesPage/CategoriesPageItem.js
@@ -3,7 +3,7 @@ import TextLink from '../../Components/TextLink'
 
 function CategoriesPageItem ({categoryData}) {
   return(
-      <TextLink className="d-flex w-100 p-0 br-btm justify-content-sb ai-center" url="/">
+      <TextLink className="txt-black d-flex w-100 p-0 br-btm justify-content-sb ai-center" url="/">
         {categoryData.category}
         <Icon icon="arrow-right"/>
     </TextLink>

--- a/src/Pages/Public/HelpPage/HelpBlock.jsx
+++ b/src/Pages/Public/HelpPage/HelpBlock.jsx
@@ -7,7 +7,7 @@ function HelpBlock({ items, dataTestId }) {
         <div data-testid={dataTestId} className="round bg-white shadow-sm">
             {items.map((item, i) => {
                 return (
-                    <Link role="link" to={item.to} className="link" key={i}>
+                    <Link role="link" to={item.to} className="link txt-black" key={i}>
                         <div className="ProductPage-btn-left row br-btm">
                             <div className="col">
                                 <div>


### PR DESCRIPTION
# Agregar clase txt-black a links

## Issue: #154 

## :memo: Resumen o Descripción:
Se agregó la clase txt-black a los links necesarios

## :camera: Screenshots:
### Sugerencias de búsqueda:

Antes
![Screenshot from 2021-12-10 13-09-54](https://user-images.githubusercontent.com/69699380/145606958-ba996334-7dff-47df-98d0-ee06b9840536.png)

Después
![Screenshot from 2021-12-10 13-22-15](https://user-images.githubusercontent.com/69699380/145606906-9a2a1c0c-b04e-4085-90a3-ca26c6956cda.png)

### Categorías:

Antes
![Screenshot from 2021-12-10 13-24-39](https://user-images.githubusercontent.com/69699380/145607350-63d4baf4-91d5-484d-88cd-43876ee949c5.png)

Después
![Screenshot from 2021-12-10 13-25-52](https://user-images.githubusercontent.com/69699380/145607442-3e1afa05-c14d-4c07-9cce-0ad40ae9d60b.png)

### Ayuda:

Antes:
![Screenshot from 2021-12-10 13-50-02](https://user-images.githubusercontent.com/69699380/145610938-b139196f-d9eb-425e-8280-8c55a048abf0.png)

Después
![Screenshot from 2021-12-10 13-50-25](https://user-images.githubusercontent.com/69699380/145611006-23add366-3c7c-4165-ac84-ba2c189cde39.png)

