### PR TITLE
Fix 180; Changed background image to url more dynamic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -895,7 +895,7 @@
 }
 
 .SearchHelp-bgi-forget {
-  background-image: url('http://localhost:3000/forget.svg');
+  background-image: url('../public/forget.svg');
   background-repeat: no-repeat;
   background-position: 10px 50%;
 }


### PR DESCRIPTION
# Arreglado la url de la imagen de fondo que era estatica en localhost.

## Issue: #

## :memo: Resumen o Descripción:
- Se cambio la url de `background-image` a `url('../public/forget.svg');`
## :camera: Screenshots:
Como quedó:
![Screenshot from 2021-12-15 14-06-24](https://user-images.githubusercontent.com/78811265/146232406-392541a2-115c-4a93-862f-b34b06856428.png)
---
Los tests pasan sin problemas menos uno que hay que cambiarlo:
![Screenshot from 2021-12-15 14-06-44](https://user-images.githubusercontent.com/78811265/146232480-d2b86ca9-ca4f-44ac-9704-bfabb25413e9.png)

